### PR TITLE
rollback emscripten version preserving the unhandled rejection fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ We encourage you to take a look `at test/index.js` to see how the functions abov
 ```
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
-./emsdk install sdk-1.38.41-64bit
-./emsdk activate sdk-1.38.41-64bit
+./emsdk install sdk-1.38.8-64bit
+./emsdk activate sdk-1.38.8-64bit
 source ./emsdk_env.sh
 cd ../
 git clone https://github.com/vacuumlabs/cardano-crypto.js
@@ -79,6 +79,10 @@ npm install
 npm run build
 shasum lib.js # should match shasum of published version of lib.js
 ```
+
+# known issues
+
+When trying to compile the library with emscripten 1.38.41, the `cardanoMemoryCombine` function slows down significantly. With the 1.38.8 version it runs significantly faster.
 
 # tests
 

--- a/test/index.js
+++ b/test/index.js
@@ -266,6 +266,16 @@ test('address packing/unpacking', async (t) => {
       2
     ),
     'Ae2tdPwUPEZCxt4UV1Uj2AMMRvg5pYPypqZowVptz3GYpK4pkcvn3EjkuNH',
-    'should properly pack V1 address'
+    'should properly pack V2 address'
+  )
+})
+
+test('proper error handling by the library', (t) => {
+  // to avoid accidentally injecting unhandledRejection handler with Emscripten
+  t.plan(1)
+  t.equals(
+    process.listeners('unhandledRejection').length,
+    0,
+    "no unhandled rejection listener should be registered"
   )
 })


### PR DESCRIPTION
With emscripten 1.38.41. `cardanoMemoryCombine` takes too much time and tests on AdaLite fail due to timeouts (and it would take too long - several seconds on the live site as well very likely). Therefore I propose rolling back emscripten to 1.38.8, and monkey patching the unhandled rejection handler.

closes #18 