### PR TITLE
Script address support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ var childWalletSecret = lib.derivePublic(parentWalletPublicKey, 1, 1)
 
 ## Address encoding/decoding/validation
 * `Buffer packBootstrapAddress(Array[int] derivationPath, Buffer xpub, Buffer hdPassphrase, int derivationScheme, int protocolMagic)`
-* `Buffer packBaseAddress(Buffer spendingKeyHash, Buffer stakingPubKey, int networkId)`
-* `Buffer packPointerAddress(Buffer pubKeyHash, Object pointer, int networkId)`
-* `Buffer packEnterpriseAddress(Buffer spendingKeyHash, int networkId)`
-* `Buffer packRewardAddress(Buffer stakingKeyHash, int networkId)`
+* `Buffer packBaseAddress(Buffer spendingHash, Buffer stakingHash, int networkId, BaseAddressType type)`
+* `Buffer packPointerAddress(Buffer spendingHash, Object pointer, int networkId, Bool isScript)`
+* `Buffer packEnterpriseAddress(Buffer spendingHash, int networkId, Bool isScript)`
+* `Buffer packRewardAddress(Buffer stakingHash, int networkId, Bool isScript)`
 * `Object getAddressType(Buffer address)`
+* `Bool hasSpendingScript(Buffer address)`
+* `Bool hasStakingScript(Buffer address)`
 * `Object getShelleyAddressInfo(Buffer address)`
 * `Object AddressTypes`
+* `Object BaseAddressTypes`
 * `Buffer addressToBuffer(string address) // address can be either bech32 or base58 encoded`
 * `Map getBootstrapAddressAttributes(Buffer address)`
 * `Array<int>? getBootstrapAddressDerivationPath(Buffer address, Buffer hdPassphrase)`

--- a/build.js
+++ b/build.js
@@ -38,6 +38,9 @@ child.on('exit', function(code){
   var patchedLib = originalLib.replace(
     `process["on"]("unhandledRejection",(function(reason,p){process["exit"](1)}));`,
     ''
+  ).replace(
+    `process["on"]("unhandledRejection",abort);`,
+    ''
   )
 
   // needed in order for the library to work in the browser


### PR DESCRIPTION
Adds script type support to addresses. 
For the base address both the spending and the staking hashes could belong to scripts instead of pubkeys.

The `isScriptAddress` and `isValidShelleyScriptAddress` currently only checks if the spending part is a script. The only "script" case that doesn't handle is the case of a base address with a public key, but the staking part is a script hash. I can break that down to 2 helper functions that check either the spending or the staking part.